### PR TITLE
Fix config file parsing

### DIFF
--- a/katello_rapidnode.py
+++ b/katello_rapidnode.py
@@ -6,17 +6,13 @@ There is very little error checking presently existing in here. Patches
 welcome. Similarly, the code as a whole is probably pretty weak... :o
 """
 from __future__ import print_function
+from configparser import ConfigParser
 from termcolor import colored
 import paramiko
 
-from sys import version_info
-if version_info[0] == 2:
-    from ConfigParser import ConfigParser  # import-error pylint:disable=F0401
-else:
-    from configparser import ConfigParser  # import-error pylint:disable=F0401
-
 # (redefining-name-from-outer-scope) pylint:disable=w0621
-CONFIG = ConfigParser().read('katello_rapidnode.ini')
+CONFIG = ConfigParser()
+CONFIG.read('katello_rapidnode.ini')
 REPO_FILE = 'myrepofile.repo'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+configparser
 paramiko
 termcolor


### PR DESCRIPTION
Add `configparser` to the list of requirements. ConfigParser saw a major update
in Python 3.2, and this module backports those changes to Python 2.6.  The
default configparser module is used in Python 3.2+, and the backported version
is used in older versions of Python.

As a side-effect of this change, drop a conditional import and do not bother
inspecting `sys.version_info`.
