### PR TITLE
Add unit tests for function `parent_get_capsules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ Code Contribution
 pip install --requirement requirements-optional.txt
 flake8 .
 pylint *.py
+./test.py
 ```

--- a/katello_rapidnode.py
+++ b/katello_rapidnode.py
@@ -7,6 +7,7 @@ welcome. Similarly, the code as a whole is probably pretty weak... :o
 """
 from __future__ import print_function
 from configparser import ConfigParser
+from locale import getdefaultlocale
 from termcolor import colored
 import paramiko
 
@@ -236,21 +237,26 @@ def parent_get_org_environments(capsule_id):
 
 
 def parent_get_capsules():
-    """Get all capsules tied to parent instance"""
-    data = []
+    """Ask the parent satellite for a list of all its capsules.
+
+    :returns: A list of strings, where each string contains ``'id,name,url'``.
+        For example: ``['1,example.com,https://example.com:9090']``.
+    :rtype: str
+
+    """
     username, password = get_credentials_parent()
-    adminpassword = CONFIG['credentials']['adminpassword']
-    command = ("hammer --username admin --password {0} --output csv "
-               "capsule list").format(adminpassword)
+    command = (
+        'hammer --username admin --password {0} --output csv capsule list'
+        .format(CONFIG['credentials']['adminpassword'])
+    )
     cmd_debug(command)
-    for results in paramiko_exec_command(PARENT, username, password, command):
-        data.append(results)
-    # Once again...
-    # print data
-    capsules = data[0].split("\n")
-    capsules.pop()
-    capsules.pop(0)
-    return capsules
+    # The unit tests have examples of what paramiko_exec_command returns.
+    return paramiko_exec_command(
+        CONFIG['servers']['parent'],
+        username,
+        password,
+        command
+    )[0].decode(getdefaultlocale()[1]).split('\n')[1:-1]
 
 
 def populate_capsules(parent):

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,2 +1,3 @@
 flake8
+mock
 pylint

--- a/test.py
+++ b/test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Unit tests for :mod:`katello_rapidnode`."""
+import katello_rapidnode
+import unittest
+
+from sys import version_info
+if version_info[0] == 2:
+    import mock  # (import-error) pylint:disable=F0401
+else:
+    from unittest import mock  # (no-name-in-module) pylint:disable=E0611
+
+
+class ParentGetCapsulesTestCase(unittest.TestCase):
+    """Tests for :func:`katello_rapidnode.parent_get_capsules`."""
+
+    def test_1_capsule(self):
+        """What happens when the server returns info about one capsule?"""
+        with mock.patch.object(
+            katello_rapidnode,
+            'paramiko_exec_command'
+        ) as cmd:
+            cmd.return_value = (
+                b'Id,Name,URL\n1,example.com,https://example.com:9090\n',
+                b''
+            )
+            self.assertEqual(
+                katello_rapidnode.parent_get_capsules(),
+                ['1,example.com,https://example.com:9090'],
+            )
+
+    def test_2_capsules(self):
+        """What happens when the server returns info about two capsules?"""
+        with mock.patch.object(
+            katello_rapidnode,
+            'paramiko_exec_command'
+        ) as cmd:
+            cmd.return_value = (
+                # Note the implicit line joins.
+                b'Id,Name,URL\n'
+                b'1,example1.com,https://example1.com:9090\n'
+                b'2,example2.com,https://example2.com:9090\n',
+                b''
+            )
+            self.assertEqual(
+                katello_rapidnode.parent_get_capsules(),
+                [
+                    '1,example1.com,https://example1.com:9090',
+                    '2,example2.com,https://example2.com:9090',
+                ],
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The new unit tests are basic, but they do prove that it is possible to import module `katello_rapidnode` without negative side effects and create unit tests for the code therein. Also, clean up function `parent_get_capsules`.
